### PR TITLE
TokenManager extension into iota-sdk update

### DIFF
--- a/sdk/src/clients/auth0.rs
+++ b/sdk/src/clients/auth0.rs
@@ -139,4 +139,21 @@ impl SecretManager for Auth0Client {
 
         Ok(TokenWrap::new(TokenType::AUTH0, token_data, token.id_token.clone()))
     }
+
+    async fn token_from_raw(&mut self, token_type: &TokenType, token: &str) -> SecretResult<TokenWrap> {
+        let client_id = token_type.client_id();
+        log::debug!("Refreshing token: {}", client_id);
+
+        let token_data = self.get_token_data(&TokenResponse {
+            access_token: "".to_string(),
+            id_token: token.to_string(),
+            refresh_token: "".to_string(),
+        }).await?;
+
+        Ok(TokenWrap::new(
+            token_type.clone(),
+            token_data,
+            token.to_string(),
+        ))
+    }
 }

--- a/sdk/src/clients/aws.rs
+++ b/sdk/src/clients/aws.rs
@@ -142,7 +142,9 @@ impl Storage for AwsClient {
     }
 
     async fn update_credentials(&mut self, _token: TokenWrap) -> StorageResult<()> {
-        todo!()
+        Self::new(token).await.map(|client| {
+            *self = client;
+        })
     }
 }
 

--- a/sdk/src/clients/keycloak.rs
+++ b/sdk/src/clients/keycloak.rs
@@ -146,4 +146,21 @@ impl SecretManager for Keycloak {
 
         Ok(TokenWrap::new(TokenType::VAULT, token_data, token.access_token.clone()))
     }
+
+    async fn token_from_raw(&mut self, token_type: &TokenType, token: &str) -> SecretResult<TokenWrap> {
+        let client_id = token_type.client_id();
+        log::debug!("Refreshing token: {}", client_id);
+
+        let token_data = self.get_token_data(&TokenResponse {
+            access_token: token.to_string(),
+            id_token: "".to_string(),
+            refresh_token: "".to_string(),
+        }).await?;
+
+        Ok(TokenWrap::new(
+            token_type.clone(),
+            token_data,
+            token.to_string(),
+        ))
+    }
 }

--- a/sdk/src/clients/mod.rs
+++ b/sdk/src/clients/mod.rs
@@ -122,6 +122,8 @@ pub trait SecretManager: Debug + Send + Sync {
     async fn get_token_with_secret(&mut self, token_type: &TokenType, client_secret: &str) -> SecretResult<TokenWrap>;
     /// Updates the refresh token used to connect to the manager
     async fn refresh_token(&mut self) -> SecretResult<TokenWrap>;
+    /// Get token data from raw token response
+    async fn token_from_raw(&mut self, token_type: &TokenType, token: &str) -> SecretResult<TokenWrap>;
 }
 
 pub(crate) fn default_secret() -> Box<impl SecretManager> {

--- a/sdk/src/clients/token.rs
+++ b/sdk/src/clients/token.rs
@@ -129,6 +129,10 @@ impl TokenManager {
         }
     }
 
+    pub async fn set_auth0_token(&mut self, token: TokenWrap) {
+        self.tokens.write().await.insert(TokenType::AUTH0, token);
+    }
+
     pub async fn auth0_token(&self) -> SecretResult<TokenWrap> {
         match self.tokens.read().await.get(&TokenType::AUTH0) {
             Some(token) => Ok(token.clone()),

--- a/sdk/src/clients/token.rs
+++ b/sdk/src/clients/token.rs
@@ -1,5 +1,4 @@
 use std::{collections::HashMap, sync::Arc};
-
 use tokio::sync::RwLock;
 
 use crate::{
@@ -66,10 +65,16 @@ impl SecretManager for TokenManager {
         Ok(token)
     }
 
-    /// Refreshes the "refresh" token. doenst update tokens held by the tokenmanager.
+    /// Refreshes the "refresh" token. Doesn't update tokens held by the tokenmanager.
     /// That operation is called refresh_token_type() or refresh()
     async fn refresh_token(&mut self) -> SecretResult<TokenWrap> {
         self.secret_manager.refresh_token().await
+    }
+
+    /// Creates a TokenWrap for a raw id token string and stores the token locally. This is for API
+    /// based functionality and won't contain the refresh token
+    async fn token_from_raw(&mut self, token_type: &TokenType, token: &str) -> SecretResult<TokenWrap> {
+        self.secret_manager.token_from_raw(token_type, token).await
     }
 }
 

--- a/sdk/src/models/token.rs
+++ b/sdk/src/models/token.rs
@@ -46,6 +46,10 @@ impl TokenWrap {
             .as_u64()
     }
 
+    pub fn token_data(&self) -> &TokenData<Value> {
+        &self.token
+    }
+
     pub fn raw(&self) -> &str {
         &self.raw
     }

--- a/sdk/src/models/vault.rs
+++ b/sdk/src/models/vault.rs
@@ -128,8 +128,9 @@ impl VaultClient {
     }
 
     pub async fn update_client_token(&mut self, token: TokenWrap) -> Result<()> {
+        let exp = token.get_expiration().unwrap();
         Self::set_client_token(&mut self.vault_client, token).await?;
-        self.exp = token.get_expiration().unwrap();
+        self.exp = exp;
         Ok(())
     }
 

--- a/sdk/src/models/vault.rs
+++ b/sdk/src/models/vault.rs
@@ -128,9 +128,9 @@ impl VaultClient {
     }
 
     pub async fn update_client_token(&mut self, token: TokenWrap) -> Result<()> {
-        let exp = token.get_expiration().unwrap();
-        Self::set_client_token(&mut self.vault_client, token).await?;
-        self.exp = exp;
+        Self::set_client_token(&mut self.vault_client, token.clone()).await?;
+        self.token = token;
+        self.exp = self.token.get_expiration().unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
Update the `iota-sdk` branch to include the `TokenManager` trait update for raw token management.