### PR TITLE
Update ValueSets types

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,10 +15,11 @@ iota_stronghold = { path = "../stronghold.rs/client"}
 async-trait = "0.1.68"
 base64 = "0.22.1"
 chrono = "0.4.26"
+convert_case = "0.6"
 fern = "0.7.0"
 futures-util = "0.3.30"
 hex = "0.4.3"
-indexmap = "2.6.0"
+indexmap = "2.7"
 isocountry = { version = "0.3" }
 jsonwebtoken = "9.3.0"
 log = "0.4"
@@ -28,8 +29,8 @@ rocket_okapi = "0.9.0"
 schemars = { version = "0.8", features = [ "chrono", "indexmap2" ] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
-thiserror = "2.0.3"
-tokio = { version = "1", features = ["full"] }
+thiserror = "2.0.4"
+tokio = { version = "1.42", features = ["full"] }
 tokio-stream = "0.1"
 url = "2.5"
 uuid = { version = "1.8.0", features = ["v4"] }
@@ -43,8 +44,8 @@ alvarium-annotator = { git = "https://github.com/project-alvarium/alvarium-annot
 
 aws-credential-types = { version = "1.2.0", optional = true }
 aws-config = { version = "1.5.6", features=["behavior-version-latest"], optional = true }
-aws-sdk-s3 = { version = "1.62.0", optional = true }
-aws-sdk-sts = { version = "1.50.0", optional = true }
+aws-sdk-s3 = { version = "1.65.0", optional = true }
+aws-sdk-sts = { version = "1.51.0", optional = true }
 
 google-cloud-storage = { git = "https://github.com/yoshidan/google-cloud-rust", branch="main", default-features=false, features=["trace","rustls-tls"], optional = true}
 

--- a/sdk/src/errors/analytics.rs
+++ b/sdk/src/errors/analytics.rs
@@ -11,4 +11,6 @@ pub type AnalyticsResult<T> = core::result::Result<T, AnalyticsError>;
 pub enum AnalyticsError {
     #[error("No vault client stored in user instance")]
     NoVaultClient,
+    #[error("No profile found by the name of {0}")]
+    NoProfileFound(String),
 }

--- a/sdk/src/models/analytics.rs
+++ b/sdk/src/models/analytics.rs
@@ -7,7 +7,6 @@ use super::{InputParameter, Parameter, Record, ValueSet};
 use crate::errors::AnalyticsError;
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(bound(deserialize = "'de: 'static"))]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyticsProfile {
     pub id: String,
@@ -17,8 +16,8 @@ pub struct AnalyticsProfile {
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Calculation {
-    pub id: &'static str,
-    pub text: &'static str,
+    pub id: String,
+    pub text: String,
     pub parameters: Vec<Parameter>,
     #[serde(skip)]
     pub calculation_function: AsyncCalculationFunctionWrapper<AnalyticsError>,

--- a/sdk/src/models/parameter.rs
+++ b/sdk/src/models/parameter.rs
@@ -1,10 +1,10 @@
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub enum Parameter {
     Static(StaticParameter),
     Input(InputParameter),
 }
 
-#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct StaticParameter {
     pub id: String,
     pub unit: String,
@@ -12,7 +12,7 @@ pub struct StaticParameter {
     pub value: f64,
 }
 
-#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct InputParameter {
     pub id: String,
     pub unit: String,

--- a/sdk/src/models/sensor.rs
+++ b/sdk/src/models/sensor.rs
@@ -27,7 +27,7 @@ pub struct Sensor {
     pub total: usize,
     // Since we occasionally divide by 0.0 this can become NAN so default to 0, or it will serialize
     // as NAN/null and break deserialization https://github.com/serde-rs/json/issues/202
-    #[serde(deserialize_with="deserialize_null_default")]
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub avgcf: f32,
     pub equipment: Equipment,
     pub readings: HashMap<String, Reading>,

--- a/sdk/src/models/site.rs
+++ b/sdk/src/models/site.rs
@@ -1,9 +1,17 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Index, IndexMut},
+};
 
 use indexmap::IndexMap;
 use rocket_okapi::okapi::schemars;
 
-use crate::models::{Equipment, GHGInfo, Notification, ProjectInfo, Record, Sensor, Sensors, ValueSet};
+use super::AnalyticsProfile;
+use crate::{
+    errors::AnalyticsError,
+    models::{Equipment, GHGInfo, Notification, ProjectInfo, Record, Sensor, Sensors, ValueSet},
+    utils::map_serialize,
+};
 
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct SiteLocation {
@@ -26,37 +34,32 @@ pub struct NewSite {
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SiteState {
-    // ToDo: Temporary alias's to be replaced with a nesting of value_sets with arbitrary names
-    #[serde(alias = "ch4_emission")]
-    pub ch4_emission: ValueSet,
-    pub wws: ValueSet,
-    #[serde(alias = "elec_prod")]
-    pub elec_prod: ValueSet,
-    #[serde(alias = "fossil_fuel")]
-    pub fossil_fuel: ValueSet,
-    pub ch4: ValueSet,
-    pub bde: ValueSet,
-    #[serde(alias = "an_dig")]
-    pub an_dig: ValueSet,
-    #[serde(alias = "biogas_adjusted")]
-    pub biogas_adjusted: ValueSet,
-    #[serde(alias = "effluent_storage")]
-    pub effluent_storage: ValueSet,
-    #[serde(alias = "ch4_destroyed")]
-    pub ch4_destroyed: ValueSet,
-    #[serde(alias = "e_project")]
-    pub e_project: ValueSet,
+    #[serde(with = "map_serialize")]
+    #[serde(flatten)]
+    #[schemars(with = "HashMap<String, ValueSet>")] // Needs to added due to with breaking jsonSchema
+    pub value_sets: HashMap<String, ValueSet>,
     #[serde(alias = "calc_data")]
     pub calc_data: Vec<Record>,
 }
 
 impl SiteState {
     pub fn get_map(&self) -> HashMap<String, serde_json::Value> {
-        // map to string to include labels
-        let str = serde_json::to_string(self).unwrap();
-        // parse the string to a HashMap
-        let map: HashMap<String, serde_json::Value> = serde_json::from_str(&str).unwrap();
-        map
+        let json_value = serde_json::to_value(self).unwrap();
+        serde_json::from_value(json_value).unwrap()
+    }
+}
+
+impl Index<&str> for SiteState {
+    type Output = ValueSet;
+
+    fn index(&self, index: &str) -> &Self::Output {
+        &self.value_sets[index]
+    }
+}
+
+impl IndexMut<&str> for SiteState {
+    fn index_mut(&mut self, index: &str) -> &mut Self::Output {
+        self.value_sets.entry(index.to_string()).or_default()
     }
 }
 
@@ -81,6 +84,8 @@ pub struct Site {
     #[serde(alias = "state_data", default)]
     pub state_data: SiteState,
     pub avg_dcf: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profiles: Option<Vec<AnalyticsProfile>>,
 }
 
 impl Site {
@@ -101,6 +106,17 @@ impl Site {
             project_announcement: announcement,
             ..Default::default()
         }
+    }
+
+    pub fn get_analytics_profile(&self, id: String) -> Result<&AnalyticsProfile, AnalyticsError> {
+        self.profiles
+            .as_ref()
+            .and_then(|profiles| profiles.iter().find(|p| p.id == id))
+            .ok_or(AnalyticsError::NoProfileFound(id))
+    }
+
+    pub fn add_analytics_profile(&mut self, profile: AnalyticsProfile) {
+        self.profiles.get_or_insert_with(Vec::new).push(profile);
     }
 }
 
@@ -129,5 +145,36 @@ impl From<&NewSite> for Site {
             sensors,
             new_site.project.clone(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::test;
+
+    use super::*;
+
+    #[test]
+    async fn test_get_map_with_camel_case_keys() {
+        let mut value_sets = HashMap::new();
+        value_sets.insert("ch4_emission".to_string(), ValueSet::default());
+        value_sets.insert("elec_prod".to_string(), ValueSet::default());
+
+        let site_state = SiteState {
+            value_sets,
+            calc_data: vec![],
+        };
+
+        let map = serde_json::to_value(site_state).unwrap();
+
+        assert!(map.get("ch4Emission").is_some());
+        assert!(map.get("elecProd").is_some());
+        assert!(map.get("calcData").is_some());
+
+        let site_state: SiteState = serde_json::from_value(map).unwrap();
+
+        assert!(site_state.value_sets.contains_key("ch4_emission"));
+        assert!(site_state.value_sets.contains_key("elec_prod"));
+        assert!(site_state.value_sets.contains_key("calc_data"));
     }
 }

--- a/sdk/src/models/valueset.rs
+++ b/sdk/src/models/valueset.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
-use crate::utils::deserialize_null_default;
+
 use chrono::{DateTime, Utc};
 
 use super::Parameter;
+use crate::utils::deserialize_null_default;
 
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ValueSet {
@@ -17,7 +18,7 @@ pub struct ValueSet {
     pub total: f64,
     // Since we occasionally divide by 0.0 this can become NAN so default to 0, or it will serialize
     // as NAN/null and break deserialization https://github.com/serde-rs/json/issues/202
-    #[serde(deserialize_with="deserialize_null_default")]
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub avg: f64,
 }
 
@@ -29,7 +30,7 @@ impl ValueSet {
         label: String,
         params: Vec<Parameter>,
     ) -> ValueSet {
-        let total = data.iter().map(|(_,v)| v).sum();
+        let total = data.iter().map(|(_, v)| v).sum();
         let avg = total / data.len() as f64;
         ValueSet {
             inputs,

--- a/sdk/src/models/valueset.rs
+++ b/sdk/src/models/valueset.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 
 use super::Parameter;
 use crate::utils::deserialize_null_default;
 use serde::Deserialize;
+
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ValueSetsWrap {
+    site_id: String,
+    value_sets: Vec<ValueSet>,
+}
 
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ValueSet {

--- a/sdk/src/models/valueset.rs
+++ b/sdk/src/models/valueset.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use crate::utils::deserialize_null_default;
+use chrono::{DateTime, Utc};
 
 use super::Parameter;
 
-#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ValueSet {
     #[serde(default)]
     pub inputs: HashMap<String, Vec<f64>>,
@@ -11,8 +12,8 @@ pub struct ValueSet {
     pub params: Vec<Parameter>,
     pub title: String,
     pub label: String,
-    pub values: Vec<f64>,
-    pub timestamps: Vec<String>,
+    #[serde(default)]
+    pub data: Vec<(DateTime<Utc>, f64)>,
     pub total: f64,
     // Since we occasionally divide by 0.0 this can become NAN so default to 0, or it will serialize
     // as NAN/null and break deserialization https://github.com/serde-rs/json/issues/202
@@ -23,21 +24,16 @@ pub struct ValueSet {
 impl ValueSet {
     pub fn new(
         inputs: HashMap<String, Vec<f64>>,
-        mut values: Vec<f64>,
-        timestamps: Vec<String>,
+        data: Vec<(DateTime<Utc>, f64)>,
         title: String,
         label: String,
         params: Vec<Parameter>,
     ) -> ValueSet {
-        if values.len() == 1 {
-            (1..timestamps.len()).for_each(|_| values.push(values[0]))
-        }
-        let total = values.iter().sum();
-        let avg = total / values.len() as f64;
+        let total = data.iter().map(|(_,v)| v).sum();
+        let avg = total / data.len() as f64;
         ValueSet {
             inputs,
-            values,
-            timestamps,
+            data,
             total,
             avg,
             title,

--- a/sdk/src/utils/analytics.rs
+++ b/sdk/src/utils/analytics.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, vec};
 
 use chrono::{DateTime, NaiveDate, Utc};
-use indexmap::IndexMap;
 use crate::{
     models::{Record, ValueSet},
     utils::feedstock_types::feedstock_types,
@@ -103,12 +102,12 @@ pub async fn equation6(feedstock_data: &[Record]) -> ValueSet {
 
 // Emissions for the Reporting Period
 pub async fn equation7(
-    eq8: IndexMap<DateTime<Utc>, f64>,
-    eq9: IndexMap<DateTime<Utc>, f64>,
-    eq10: IndexMap<DateTime<Utc>, f64>,
+    eq8: Vec<(DateTime<Utc>, f64)>,
+    eq9: Vec<(DateTime<Utc>, f64)>,
+    eq10: Vec<(DateTime<Utc>, f64)>,
     calc_data: &[Record],
-    eq12: IndexMap<DateTime<Utc>, f64>,
-    eq15: IndexMap<DateTime<Utc>, f64>,
+    eq12: Vec<(DateTime<Utc>, f64)>,
+    eq15: Vec<(DateTime<Utc>, f64)>,
 ) -> ValueSet {
     let daily_biogas = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
     let daily_biogas_no_flare = daily_average(calc_data, "Biogás Generado sin antorcha (Nm3)", true).await;
@@ -130,7 +129,7 @@ pub async fn equation7(
             .enumerate()
             .map(|(i, (timestamp, record))| (
                 timestamp.clone(),
-                record + eq8[i] + eq9[i] + eq10[i] + flare_e[i].1 + eq15[i]
+                record + eq8[i].1 + eq9[i].1 + eq10[i].1 + flare_e[i].1 + eq15[i].1
             ))
             .collect()
     } else {
@@ -162,7 +161,7 @@ pub async fn equation9() -> f64 {
 }
 
 // Anaerobic Digestor
-pub async fn equation10(bde: IndexMap<DateTime<Utc>, f64>, ch4: IndexMap<DateTime<Utc>, f64>, calc_data: &[Record]) -> ValueSet {
+pub async fn equation10(bde: Vec<(DateTime<Utc>, f64)>, ch4: Vec<(DateTime<Utc>, f64)>, calc_data: &[Record]) -> ValueSet {
     let ad = 0.98;
     let ch4_vent = 0.0;
 
@@ -171,9 +170,9 @@ pub async fn equation10(bde: IndexMap<DateTime<Utc>, f64>, ch4: IndexMap<DateTim
     let result: Vec<(DateTime<Utc>, f64)> = if !bde.is_empty() && !ch4.is_empty() && !daily_f_mo.is_empty() {
         bde.iter()
             .enumerate()
-            .map(|(i, (date, &record))| {
-                let n = if record == 0.0 || ch4[i] == 0.0 { 1.0 } else { 2.0 };
-                (date.clone(), GWP_CH4 * (ch4[i] * (n / (ad - record) + ch4_vent)))
+            .map(|(i, (date, record))| {
+                let n = if *record == 0.0 || ch4[i].1 == 0.0 { 1.0 } else { 2.0 };
+                (date.clone(), GWP_CH4 * (ch4[i].1 * (n / (ad - record) + ch4_vent)))
             })
             .collect()
     } else {

--- a/sdk/src/utils/analytics.rs
+++ b/sdk/src/utils/analytics.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, vec};
 
-use chrono::NaiveDate;
-
+use chrono::{DateTime, NaiveDate, Utc};
+use indexmap::IndexMap;
 use crate::{
     models::{Record, ValueSet},
     utils::feedstock_types::feedstock_types,
@@ -28,17 +28,21 @@ pub async fn equation5(feedstock_data: &[Record], cod_lab_sheet: f64) -> ValueSe
         .cloned()
         .collect::<Vec<Record>>();
 
-    let (daily_feedstock, data_timestamp) = daily_average(&q_ww_s_i, "Toneladas ", true).await;
+    let daily_feedstock = daily_average(&q_ww_s_i, "Toneladas ", true).await;
 
-    let result: Vec<f64> = daily_feedstock
+    let result: Vec<(DateTime<Utc>, f64)> = daily_feedstock
         .iter()
-        .map(|record| (record.sum + cod_lab_sheet) * B_OWW_S * MCF_ATS * GWP_CH4 * UNCERTAINTY_FACTOR)
+        .map(|record| {
+            (
+                record.data_timestamp.and_utc(),
+                (record.sum + cod_lab_sheet) * B_OWW_S * MCF_ATS * GWP_CH4 * UNCERTAINTY_FACTOR
+            )
+        })
         .collect();
 
     ValueSet::new(
         HashMap::new(),
         result,
-        data_timestamp,
         "Waste Water (liquid industrial waste)".to_string(),
         "Tonnes".to_string(),
         vec![],
@@ -47,9 +51,9 @@ pub async fn equation5(feedstock_data: &[Record], cod_lab_sheet: f64) -> ValueSe
 
 // Methane emissions from solid waste disposal sites (using first order decay method)
 pub async fn equation6(feedstock_data: &[Record]) -> ValueSet {
-    let (daily_feedstock, data_timestamp) = daily_average(feedstock_data, "Toneladas ", true).await;
+    let daily_feedstock = daily_average(feedstock_data, "Toneladas ", true).await;
 
-    let result: Vec<f64> = daily_feedstock
+    let result: Vec<(DateTime<Utc>, f64)> = daily_feedstock
         .iter()
         .map(|record| {
             let cod_ww_s_i = 1.0;
@@ -66,7 +70,7 @@ pub async fn equation6(feedstock_data: &[Record]) -> ValueSet {
                 record.sum
             };
 
-            if feedstock_type.is_some() && feedstock_type.unwrap().type_of_feedstock.as_str() == "Manure" {
+            let value = if feedstock_type.is_some() && feedstock_type.unwrap().type_of_feedstock.as_str() == "Manure" {
                 0.21 * 0.03 * GWP_CH4 * UNCERTAINTY_FACTOR * (sum + cod_ww_s_i)
             } else {
                 let (doc, fie, f_y) = feedstock_type
@@ -83,14 +87,14 @@ pub async fn equation6(feedstock_data: &[Record]) -> ValueSet {
                     * doc
                     * f64::exp(-K * Y - X)
                     * (1.0 - f64::exp(-K))
-            }
+            };
+            (record.data_timestamp.and_utc(), value)
         })
         .collect();
 
     ValueSet::new(
         HashMap::new(),
         result,
-        data_timestamp,
         "Methane emissions from solid waste disposal sites".to_string(),
         "t C02e".to_string(),
         vec![],
@@ -99,36 +103,47 @@ pub async fn equation6(feedstock_data: &[Record]) -> ValueSet {
 
 // Emissions for the Reporting Period
 pub async fn equation7(
-    eq8: Vec<f64>,
-    eq9: Vec<f64>,
-    eq10: Vec<f64>,
+    eq8: IndexMap<DateTime<Utc>, f64>,
+    eq9: IndexMap<DateTime<Utc>, f64>,
+    eq10: IndexMap<DateTime<Utc>, f64>,
     calc_data: &[Record],
-    eq12: Vec<f64>,
-    eq15: Vec<f64>,
-) -> Vec<f64> {
+    eq12: IndexMap<DateTime<Utc>, f64>,
+    eq15: IndexMap<DateTime<Utc>, f64>,
+) -> ValueSet {
     let daily_biogas = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
     let daily_biogas_no_flare = daily_average(calc_data, "Biogás Generado sin antorcha (Nm3)", true).await;
-    let flare_e: Vec<f64> = if !daily_biogas.0.is_empty() && !daily_biogas_no_flare.0.is_empty() {
+    let flare_e: Vec<(DateTime<Utc>, f64)> = if !daily_biogas.is_empty() && !daily_biogas_no_flare.is_empty() {
         daily_biogas
-            .0
             .iter()
             .enumerate()
-            .map(|(i, record)| record.sum - daily_biogas_no_flare.0[i].sum)
+            .map(|(i, record)| (
+                record.data_timestamp.and_utc(),
+                record.sum - daily_biogas_no_flare[i].sum
+            ))
             .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
-    let result: Vec<f64> = if !eq12.is_empty() {
+    let result: Vec<(DateTime<Utc>, f64)> = if !eq12.is_empty() {
         eq12.iter()
             .enumerate()
-            .map(|(i, &record)| record + eq8[i] + eq9[i] + eq10[i] + flare_e[i] + eq15[i])
+            .map(|(i, (timestamp, record))| (
+                timestamp.clone(),
+                record + eq8[i] + eq9[i] + eq10[i] + flare_e[i].1 + eq15[i]
+            ))
             .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
-    result
+    ValueSet::new(
+        HashMap::new(),
+        result,
+        "Emissions for the Reporting Period".to_string(),
+        "t C02e".to_string(),
+        vec![],
+    )
 }
 
 // Electricity Generation and Transmission
@@ -147,28 +162,27 @@ pub async fn equation9() -> f64 {
 }
 
 // Anaerobic Digestor
-pub async fn equation10(bde: Vec<f64>, ch4: Vec<f64>, calc_data: &[Record]) -> ValueSet {
+pub async fn equation10(bde: IndexMap<DateTime<Utc>, f64>, ch4: IndexMap<DateTime<Utc>, f64>, calc_data: &[Record]) -> ValueSet {
     let ad = 0.98;
     let ch4_vent = 0.0;
 
     let daily_f_mo = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
 
-    let result: Vec<f64> = if !bde.is_empty() && !ch4.is_empty() && !daily_f_mo.0.is_empty() {
+    let result: Vec<(DateTime<Utc>, f64)> = if !bde.is_empty() && !ch4.is_empty() && !daily_f_mo.is_empty() {
         bde.iter()
             .enumerate()
-            .map(|(i, &record)| {
+            .map(|(i, (date, &record))| {
                 let n = if record == 0.0 || ch4[i] == 0.0 { 1.0 } else { 2.0 };
-                GWP_CH4 * (ch4[i] * (n / (ad - record) + ch4_vent))
+                (date.clone(), GWP_CH4 * (ch4[i] * (n / (ad - record) + ch4_vent)))
             })
             .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
     ValueSet::new(
         HashMap::new(),
         result,
-        daily_f_mo.1,
         "Anaerobic Digestor".to_string(),
         "t C02e".to_string(),
         vec![],
@@ -183,24 +197,22 @@ pub async fn equation11(calc_data: &[Record]) -> ValueSet {
     let daily_f_mo = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
     let daily_ch4_conc_mo = daily_average(calc_data, "%CH4 DF", true).await;
 
-    let result: Vec<f64> = if !daily_f_mo.0.is_empty() && !daily_ch4_conc_mo.0.is_empty() {
+    let result: Vec<(DateTime<Utc>, f64)> = if !daily_f_mo.is_empty() && !daily_ch4_conc_mo.is_empty() {
         daily_f_mo
-            .0
             .iter()
             .enumerate()
-            .map(|(i, record)| {
-                ////info!("Sum: {}", record.sum);
-                record.sum * daily_ch4_conc_mo.0[i].sum * methane_density * conversion_factor
-            })
+            .map(|(i, record)| (
+                record.data_timestamp.and_utc(),
+                record.sum * daily_ch4_conc_mo[i].sum * methane_density * conversion_factor
+            ))
             .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
     ValueSet::new(
         HashMap::new(),
         result,
-        daily_f_mo.1,
         "Quantity of Methane Collected and Metered".to_string(),
         "t CH4".to_string(),
         vec![],
@@ -213,16 +225,17 @@ pub async fn equation12(calc_data: &[Record]) -> ValueSet {
 
     let daily_calc_data = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
 
-    let result: Vec<f64> = if !daily_calc_data.0.is_empty() {
-        daily_calc_data.0.iter().map(|record| record.sum * bde_dd).collect()
+    let result: Vec<(DateTime<Utc>, f64)> = if !daily_calc_data.is_empty() {
+        daily_calc_data.iter()
+            .map(|record| (record.data_timestamp.and_utc(), record.sum * bde_dd))
+            .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
     ValueSet::new(
         HashMap::new(),
         result,
-        daily_calc_data.1,
         "Weighted Biogas average of all destruction devices used".to_string(),
         "Nm3".to_string(),
         vec![],
@@ -236,20 +249,18 @@ pub async fn equation14(calc_data: &[Record]) -> ValueSet {
 
     let daily_calc_data = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
 
-    let result: Vec<f64> = if !daily_calc_data.0.is_empty() {
+    let result: Vec<(DateTime<Utc>, f64)> = if !daily_calc_data.is_empty() {
         daily_calc_data
-            .0
             .iter()
-            .map(|record| record.sum * (520.0 / t) * p)
+            .map(|record| (record.data_timestamp.and_utc(), record.sum * (520.0 / t) * p))
             .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
     ValueSet::new(
         HashMap::new(),
         result,
-        daily_calc_data.1,
         "Volume of biogas collected for the given time interval".to_string(),
         "Nm3".to_string(),
         vec![],
@@ -264,20 +275,21 @@ pub async fn equation15(calc_data: &[Record]) -> ValueSet {
 
     let daily_calc_data = daily_average(calc_data, "Biogás Generado (Nm3)", true).await;
 
-    let result: Vec<f64> = if !daily_calc_data.0.is_empty() {
+    let result: Vec<(DateTime<Utc>, f64)> = if !daily_calc_data.is_empty() {
         daily_calc_data
-            .0
             .iter()
-            .map(|record| b_0_ef * methane_conversion_factor * gwp_ch4 * record.sum)
+            .map(|record| (
+                record.data_timestamp.and_utc(),
+                b_0_ef * methane_conversion_factor * gwp_ch4 * record.sum
+            ))
             .collect()
     } else {
-        vec![]
+        Vec::new()
     };
 
     ValueSet::new(
         HashMap::new(),
         result,
-        daily_calc_data.1,
         "Total GHG Emissions for Effluent Storage for the Reporting Period".to_string(),
         "t C02e".to_string(),
         vec![],
@@ -291,33 +303,28 @@ pub async fn equation18(calc_data: &[Record]) -> ValueSet {
     let daily_biogas_no_flare = daily_average(calc_data, "Biogás Generado sin antorcha (Nm3)", true).await;
     let daily_ch4_meter = daily_average(calc_data, "%CH4 DF", true).await;
 
-    let mut result: Vec<f64> = Vec::new();
+    let mut result: Vec<(DateTime<Utc>, f64)> = Vec::new();
 
-    if !daily_biogas.0.is_empty() {
-        for i in 0..daily_biogas.0.len() {
-            let n = if daily_biogas.0[i].sum == 0.0 || daily_biogas_no_flare.0[i].sum == 0.0 {
+    if !daily_biogas.is_empty() {
+        for i in 0..daily_biogas.len() {
+            let n = if daily_biogas[i].sum == 0.0 || daily_biogas_no_flare[i].sum == 0.0 {
                 1.0
             } else {
                 2.0
             };
 
             let value =
-                ((daily_biogas.0[i].sum + daily_biogas_no_flare.0[i].sum) / n) * daily_ch4_meter.0[i].sum * GWP_CH4;
+                ((daily_biogas[i].sum + daily_biogas_no_flare[i].sum) / n) * daily_ch4_meter[i].sum * GWP_CH4;
 
-            result.push(value);
+            if !result.iter().any(|(timestamp, _)| timestamp == &daily_biogas[i].data_timestamp.and_utc()) {
+                result.push((daily_biogas[i].data_timestamp.and_utc(), value));
+            }
         }
     }
-
-    let data_timestamp = if daily_biogas.1.len() > 1 {
-        daily_biogas.1.clone()
-    } else {
-        vec![]
-    };
 
     ValueSet::new(
         HashMap::new(),
         result,
-        data_timestamp,
         "Total Metered Quantity of Methane Captured and Destroyed by Anaerobic Digestion".to_string(),
         "t CH4".to_string(),
         vec![],
@@ -337,9 +344,8 @@ pub struct SensorAverage<'a> {
     pub records: Vec<&'a Record>,
 }
 
-pub async fn daily_average(data: &[Record], dataset: &str, _calc: bool) -> (Vec<Record>, Vec<String>) {
+pub async fn daily_average(data: &[Record], dataset: &str, _calc: bool) -> Vec<Record> {
     let mut daily_sensor_data: Vec<Record> = Vec::new();
-    let mut period_timestamp_arr: Vec<String> = Vec::new();
     let daily_data = all_daily_averages(data).await;
 
     ////info!("Daily Data: {:?}", daily_data);
@@ -349,14 +355,13 @@ pub async fn daily_average(data: &[Record], dataset: &str, _calc: bool) -> (Vec<
                 ////info!("Raw? {}", record.raw.as_ref().and_then(|raw| raw.get(dataset)).is_some());
                 if dataset.eq("Toneladas ") || record.raw.as_ref().and_then(|raw| raw.get(dataset)).is_some() {
                     daily_sensor_data.push((*record).clone());
-                    period_timestamp_arr.push(record.data_timestamp.and_utc().to_rfc3339());
                 }
             }
         })
     });
     ////info!("Daily sensor Data: {}", daily_sensor_data.len());
 
-    (daily_sensor_data, period_timestamp_arr)
+    daily_sensor_data
 }
 
 pub async fn all_daily_averages(data: &[Record]) -> HashMap<NaiveDate, DailyAverage> {

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -1,12 +1,14 @@
 pub mod analytics;
 pub use analytics::*;
 
+pub mod serde;
+pub use serde::*;
+
 pub mod constants;
 use base64::Engine;
 pub use constants::*;
 use iota_sdk::crypto::signatures::ed25519::SecretKey;
 use log::info;
-use serde::Deserialize;
 
 pub fn new_stronghold_key() -> String {
     let key = SecretKey::generate().expect("Shouldn't be a problem to generate a new key");
@@ -151,13 +153,4 @@ pub mod feedstock_types {
 
 pub fn make_session_id() -> String {
     uuid::Uuid::new_v4().to_string()
-}
-
-pub fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    T: Default + Deserialize<'de>,
-    D: serde::Deserializer<'de>,
-{
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
 }

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -153,7 +153,6 @@ pub fn make_session_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
-
 pub fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     T: Default + Deserialize<'de>,

--- a/sdk/src/utils/serde.rs
+++ b/sdk/src/utils/serde.rs
@@ -1,0 +1,79 @@
+use ::serde::Deserialize;
+
+pub fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
+
+pub mod map_serialize {
+    use std::{collections::HashMap, fmt};
+
+    use convert_case::{Boundary, Case, Casing};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor, ser::SerializeMap};
+
+    pub fn serialize<'a, T, K, V, S>(target: T, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: IntoIterator<Item = (&'a K, &'a V)>,
+        K: Serialize + Casing<String> + 'a,
+        V: Serialize + 'a,
+    {
+        let container: Vec<_> = target.into_iter().collect();
+        let mut map = ser.serialize_map(Some(container.len()))?;
+        for (k, v) in container {
+            let key = k.to_case(Case::Camel);
+            map.serialize_entry(&key, v)?;
+        }
+        map.end()
+    }
+
+    pub fn deserialize<'de, K, V, D>(deserializer: D) -> Result<HashMap<K, V>, D::Error>
+    where
+        D: Deserializer<'de>,
+        K: Deserialize<'de> + Casing<String> + From<String> + Eq + std::hash::Hash,
+        V: Deserialize<'de>,
+    {
+        struct MapVisitor<K, V> {
+            marker: std::marker::PhantomData<(K, V)>,
+        }
+
+        impl<'de, K, V> Visitor<'de> for MapVisitor<K, V>
+        where
+            K: Deserialize<'de> + Casing<String> + From<String> + Eq + std::hash::Hash,
+            V: Deserialize<'de>,
+        {
+            type Value = HashMap<K, V>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a map with camelCase keys")
+            }
+
+            fn visit_map<A>(self, mut de_map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut map = HashMap::with_capacity(de_map.size_hint().unwrap_or_default());
+
+                while let Some((k, v)) = de_map.next_entry::<String, _>()? {
+                    map.insert(
+                        k.from_case(Case::Camel)
+                            .without_boundaries(&[Boundary::UpperDigit, Boundary::LowerDigit]) // Needed to not make ch_4_emission
+                            .to_case(Case::Snake)
+                            .into(),
+                        v,
+                    );
+                }
+
+                Ok(map)
+            }
+        }
+
+        deserializer.deserialize_map(MapVisitor {
+            marker: std::marker::PhantomData,
+        })
+    }
+}


### PR DESCRIPTION
# Description of change
ValueSets needed an update to unify `Timestamps` and `Values`. Each were stored in independent `Vec`'s which meant they did not retain a unified order between the two. This leads to jumps in the charts because the values don't align with the timestamps they're supposed to anymore. 

This will be breaking for existing `ValueSet`s though, so we may want to consider accounting for that in the Application deserialization for `SiteState`. #11 outlines the new `SiteState` that will replace the existing hardcoded one, but in the meantime this update will break the serde for the old `SiteState`. 

ToDo: 
- [x] Test Boilerplate with new `ValueSet` serde
- [x] Test Analytics with new `ValueSet` serde 
- [ ] Test Retriever with new `ValueSet` serde
- [ ] Test API with new `ValueSet` serde 

Fixes #12 
